### PR TITLE
Use relative paths for header inclusion

### DIFF
--- a/aesc/CMakeLists.txt
+++ b/aesc/CMakeLists.txt
@@ -9,11 +9,6 @@ add_subdirectory(internal)
 add_subdirectory(control)
 add_subdirectory(render)
 
-target_include_directories(aesc
-    PUBLIC
-        ${PROJECT_SOURCE_DIR}
-)
-
 target_compile_features(aesc
     PUBLIC
         cxx_std_11

--- a/aesc/aesc.hpp
+++ b/aesc/aesc.hpp
@@ -1,10 +1,10 @@
 #ifndef AESC_AESC_HPP_
 #define AESC_AESC_HPP_
 
-#include "aesc/control/cursor.hpp"
-#include "aesc/render/color.hpp"
-#include "aesc/render/color256.hpp"
-#include "aesc/render/render.hpp"
-#include "aesc/render/truecolor.hpp"
+#include "control/cursor.hpp"
+#include "render/color.hpp"
+#include "render/color256.hpp"
+#include "render/render.hpp"
+#include "render/truecolor.hpp"
 
 #endif  // AESC_AESC_HPP_

--- a/aesc/control/cursor.cpp
+++ b/aesc/control/cursor.cpp
@@ -2,7 +2,7 @@
  * Wraps cursor control sequences
  */
 
-#include "aesc/control/cursor.hpp"
+#include "cursor.hpp"
 
 namespace aesc {  // Ansi Escape Terminal
 

--- a/aesc/control/cursor.hpp
+++ b/aesc/control/cursor.hpp
@@ -5,8 +5,8 @@
 #ifndef AESC_CONTROL_CURSOR_HPP_
 #define AESC_CONTROL_CURSOR_HPP_
 
-#include "aesc/internal/manipulator.hpp"
-#include "aesc/internal/sequences.hpp"
+#include "../internal/manipulator.hpp"
+#include "../internal/sequences.hpp"
 
 namespace aesc {  // Ansi Escape Terminal
 

--- a/aesc/internal/manipulator.cpp
+++ b/aesc/internal/manipulator.cpp
@@ -2,7 +2,7 @@
  * Manipulators of general output streams that take one or three arguments
  */
 
-#include "aesc/internal/manipulator.hpp"
+#include "manipulator.hpp"
 
 namespace aesc {  // Ansi Escape Terminal
 

--- a/aesc/render/color.cpp
+++ b/aesc/render/color.cpp
@@ -2,10 +2,10 @@
  * Wrap 4-bit color codes within general output streams
  */
 
-#include "aesc/render/color.hpp"
+#include "color.hpp"
 
-#include "aesc/internal/sequences.hpp"
-#include "aesc/render/internal.hpp"
+#include "../internal/sequences.hpp"
+#include "internal.hpp"
 
 namespace aesc {  // Ansi Escape Terminal
 

--- a/aesc/render/color256.cpp
+++ b/aesc/render/color256.cpp
@@ -2,12 +2,12 @@
  * Wrap 8-bit color codes within general output streams
  */
 
-#include "aesc/render/color256.hpp"
+#include "color256.hpp"
 
 #include <stdexcept>
 
-#include "aesc/internal/sequences.hpp"
-#include "aesc/render/internal.hpp"
+#include "../internal/sequences.hpp"
+#include "internal.hpp"
 
 namespace aesc {  // Ansi Escape Terminal
 

--- a/aesc/render/color256.hpp
+++ b/aesc/render/color256.hpp
@@ -5,7 +5,7 @@
 #ifndef AESC_RENDER_COLOR256_HPP_
 #define AESC_RENDER_COLOR256_HPP_
 
-#include "aesc/internal/manipulator.hpp"
+#include "../internal/manipulator.hpp"
 
 namespace aesc {  // Ansi Escape Terminal
 

--- a/aesc/render/render.cpp
+++ b/aesc/render/render.cpp
@@ -2,10 +2,10 @@
  * Wrap the Select Graphic Rendition codes
  */
 
-#include "aesc/render/render.hpp"
+#include "render.hpp"
 
-#include "aesc/internal/sequences.hpp"
-#include "aesc/render/internal.hpp"
+#include "../internal/sequences.hpp"
+#include "internal.hpp"
 
 namespace aesc {  // Ansi Escape Terminal
 

--- a/aesc/render/truecolor.cpp
+++ b/aesc/render/truecolor.cpp
@@ -2,12 +2,12 @@
  * Wrap 24-bit true color codes within general output streams
  */
 
-#include "aesc/render/truecolor.hpp"
+#include "truecolor.hpp"
 
 #include <stdexcept>
 
-#include "aesc/internal/sequences.hpp"
-#include "aesc/render/internal.hpp"
+#include "../internal/sequences.hpp"
+#include "internal.hpp"
 
 namespace aesc {  // Ansi Escape Terminal
 

--- a/aesc/render/truecolor.hpp
+++ b/aesc/render/truecolor.hpp
@@ -7,7 +7,7 @@
 
 #include <iostream>
 
-#include "aesc/internal/manipulator.hpp"
+#include "../internal/manipulator.hpp"
 
 namespace aesc {  // Ansi Escape Terminal
 


### PR DESCRIPTION
Remove build system (CMake) dependency.
Closes #19